### PR TITLE
fix: resolve dependency paths with require.resolve

### DIFF
--- a/packages/nx-boot-gradle/src/executors/kformat/executor.ts
+++ b/packages/nx-boot-gradle/src/executors/kformat/executor.ts
@@ -1,5 +1,9 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
-import { getProjectSourceRoot, runCommand } from '../../utils/command';
+import {
+  getDependencyRoot,
+  getProjectSourceRoot,
+  runCommand,
+} from '../../utils/command';
 import { KotlinFormatExecutorSchema } from './schema';
 
 export default async function runExecutor(
@@ -9,7 +13,12 @@ export default async function runExecutor(
   logger.info(`Executor ran for Kotlin Format: ${JSON.stringify(options)}`);
   const projectSourceRoot = getProjectSourceRoot(context);
 
-  const command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ./node_modules/@jnxplus/ktlint/ktlint -F "${projectSourceRoot}/**/*.kt"`;
+  const ktlintRoot = getDependencyRoot(
+    '@jnxplus/ktlint',
+    `./node_modules/@jnxplus/ktlint`
+  );
+
+  const command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ${ktlintRoot}/ktlint -F "${projectSourceRoot}/**/*.kt"`;
 
   return runCommand(command);
 }

--- a/packages/nx-boot-gradle/src/executors/lint/executor.ts
+++ b/packages/nx-boot-gradle/src/executors/lint/executor.ts
@@ -1,5 +1,10 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
-import { getProjectSourceRoot, runCommand } from '../../utils/command';
+
+import {
+  getProjectSourceRoot,
+  runCommand,
+  getDependencyRoot,
+} from '../../utils/command';
 import { LintExecutorSchema } from './schema';
 
 export default async function runExecutor(
@@ -9,17 +14,29 @@ export default async function runExecutor(
   logger.info(`Executor ran for Lint: ${JSON.stringify(options)}`);
   let command: string;
   const projectSourceRoot = getProjectSourceRoot(context);
+  const checkstyleRoot = getDependencyRoot(
+    '@jnxplus/checkstyle',
+    `./node_modules/@jnxplus/checkstyle`
+  );
+  const pmdRoot = getDependencyRoot(
+    '@jnxplus/pmd',
+    `./node_modules/@jnxplus/pmd`
+  );
+  const ktlintRoot = getDependencyRoot(
+    '@jnxplus/ktlint',
+    `./node_modules/@jnxplus/ktlint`
+  );
 
   if (options.linter === 'checkstyle') {
-    command = `java -jar ./node_modules/@jnxplus/checkstyle/checkstyle.jar -c ./tools/linters/checkstyle.xml ${projectSourceRoot}`;
+    command = `java -jar ${checkstyleRoot}/checkstyle.jar -c ./tools/linters/checkstyle.xml ${projectSourceRoot}`;
   }
 
   if (options.linter === 'pmd') {
-    command = `java -cp ./node_modules/@jnxplus/pmd/lib/*${getClassPathDelimiter()}. net.sourceforge.pmd.PMD -R ./tools/linters/pmd.xml -d ${projectSourceRoot}`;
+    command = `java -cp ${pmdRoot}/lib/*${getClassPathDelimiter()}. net.sourceforge.pmd.PMD -R ./tools/linters/pmd.xml -d ${projectSourceRoot}`;
   }
 
   if (options.linter === 'ktlint') {
-    command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ./node_modules/@jnxplus/ktlint/ktlint "${projectSourceRoot}/**/*.kt"`;
+    command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ${ktlintRoot}/ktlint "${projectSourceRoot}/**/*.kt"`;
   }
 
   return runCommand(command);

--- a/packages/nx-boot-gradle/src/utils/command.ts
+++ b/packages/nx-boot-gradle/src/utils/command.ts
@@ -1,6 +1,6 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
 import { execSync } from 'child_process';
-import { normalize } from 'path';
+import { resolve } from 'path';
 
 export async function waitForever() {
   return new Promise(() => {
@@ -40,4 +40,12 @@ export function getProjectSourceRoot(context: ExecutorContext) {
 
 export function normalizeName(name: string) {
   return name.replace(/[^0-9a-zA-Z]/g, '-');
+}
+
+export function getDependencyRoot(dependency, defaultPath) {
+  try {
+    return resolve(require.resolve(dependency), '../..');
+  } catch (error) {
+    return defaultPath;
+  }
 }

--- a/packages/nx-boot-maven/src/executors/kformat/executor.ts
+++ b/packages/nx-boot-maven/src/executors/kformat/executor.ts
@@ -1,5 +1,9 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
-import { getProjectSourceRoot, runCommand } from '../../utils/command';
+import {
+  getDependencyRoot,
+  getProjectSourceRoot,
+  runCommand,
+} from '../../utils/command';
 import { KotlinFormatExecutorSchema } from './schema';
 
 export default async function runExecutor(
@@ -8,8 +12,12 @@ export default async function runExecutor(
 ) {
   logger.info(`Executor ran for Kotlin Format: ${JSON.stringify(options)}`);
   const projectSourceRoot = getProjectSourceRoot(context);
+  const ktlintRoot = getDependencyRoot(
+    '@jnxplus/ktlint',
+    `./node_modules/@jnxplus/ktlint`
+  );
 
-  const command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ./node_modules/@jnxplus/ktlint/ktlint -F "${projectSourceRoot}/**/*.kt"`;
+  const command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ${ktlintRoot}/ktlint -F "${projectSourceRoot}/**/*.kt"`;
 
   return runCommand(command);
 }

--- a/packages/nx-boot-maven/src/executors/lint/executor.ts
+++ b/packages/nx-boot-maven/src/executors/lint/executor.ts
@@ -1,5 +1,9 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
-import { getProjectSourceRoot, runCommand } from '../../utils/command';
+import {
+  getDependencyRoot,
+  getProjectSourceRoot,
+  runCommand,
+} from '../../utils/command';
 import { LintExecutorSchema } from './schema';
 
 export default async function runExecutor(
@@ -9,17 +13,29 @@ export default async function runExecutor(
   logger.info(`Executor ran for Lint: ${JSON.stringify(options)}`);
   let command: string;
   const projectSourceRoot = getProjectSourceRoot(context);
+  const checkstyleRoot = getDependencyRoot(
+    '@jnxplus/checkstyle',
+    `./node_modules/@jnxplus/checkstyle`
+  );
+  const pmdRoot = getDependencyRoot(
+    '@jnxplus/pmd',
+    `./node_modules/@jnxplus/pmd`
+  );
+  const ktlintRoot = getDependencyRoot(
+    '@jnxplus/ktlint',
+    `./node_modules/@jnxplus/ktlint`
+  );
 
   if (options.linter === 'checkstyle') {
-    command = `java -jar ./node_modules/@jnxplus/checkstyle/checkstyle.jar -c ./tools/linters/checkstyle.xml ${projectSourceRoot}`;
+    command = `java -jar ${checkstyleRoot}/checkstyle.jar -c ./tools/linters/checkstyle.xml ${projectSourceRoot}`;
   }
 
   if (options.linter === 'pmd') {
-    command = `java -cp ./node_modules/@jnxplus/pmd/lib/*${getClassPathDelimiter()}. net.sourceforge.pmd.PMD -R ./tools/linters/pmd.xml -d ${projectSourceRoot}`;
+    command = `java -cp ${pmdRoot}/lib/*${getClassPathDelimiter()}. net.sourceforge.pmd.PMD -R ./tools/linters/pmd.xml -d ${projectSourceRoot}`;
   }
 
   if (options.linter === 'ktlint') {
-    command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ./node_modules/@jnxplus/ktlint/ktlint "${projectSourceRoot}/**/*.kt"`;
+    command = `java --add-opens java.base/java.lang=ALL-UNNAMED -jar ${ktlintRoot}/ktlint "${projectSourceRoot}/**/*.kt"`;
   }
 
   return runCommand(command);

--- a/packages/nx-boot-maven/src/utils/command.ts
+++ b/packages/nx-boot-maven/src/utils/command.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext, logger } from '@nrwl/devkit';
 import { execSync } from 'child_process';
+import { resolve } from 'path';
 
 export async function waitForever() {
   return new Promise(() => {
@@ -38,4 +39,12 @@ export function getProjectSourceRoot(context: ExecutorContext) {
 
 export function normalizeName(name: string) {
   return name.replace(/[^0-9a-zA-Z]/g, '-');
+}
+
+export function getDependencyRoot(dependency, defaultPath) {
+  try {
+    return resolve(require.resolve(dependency), '../..');
+  } catch (error) {
+    return defaultPath;
+  }
 }


### PR DESCRIPTION
This fix resolve dependency paths consistently for all node package managers

Notably pnpm:
-  pnpm installs packages differently where transitive dependencies are in a `.pnpm` folder and uses symlinks to link packages.

relates to #15 