### PR TITLE
chore: use latest pattern build as default

### DIFF
--- a/packages/nx-boot-gradle/src/dep-graph/lookup-deps.ts
+++ b/packages/nx-boot-gradle/src/dep-graph/lookup-deps.ts
@@ -100,5 +100,7 @@ function getDependencyProjectName(
   const root = folders.join('/');
   const node = managedProjects.find((project) => project.data.root === root);
 
-  return node?.name || folders.pop();
+  return (
+    node?.name || gradleProjectPath.split(':libs:').pop().replace(/:/g, '-')
+  );
 }


### PR DESCRIPTION
use the latest pattern build as a sensible fallback

relates to #15 