### PR TITLE
fix: dep-graph for nx > 14.2.x

### DIFF
--- a/packages/nx-boot-maven/src/dep-graph/lookup-deps.ts
+++ b/packages/nx-boot-maven/src/dep-graph/lookup-deps.ts
@@ -3,10 +3,11 @@ import {
   ProjectGraphBuilder,
   ProjectGraphNode,
   ProjectGraphProcessorContext,
+  workspaceRoot,
 } from '@nrwl/devkit';
-import { appRootPath, fileExists } from '@nrwl/tao/src/utils/app-root';
 import { join } from 'path';
 import { XmlDocument } from 'xmldoc';
+import { fileExists } from '../utils/fileutils';
 import { readXml2 } from '../utils/xml';
 
 export function processProjectGraph(
@@ -19,7 +20,7 @@ export function processProjectGraph(
   const projectNames = projects.map((project) => project.name);
 
   for (const project of projects) {
-    const pomXmlPath = join(appRootPath, project.data.root, 'pom.xml');
+    const pomXmlPath = join(workspaceRoot, project.data.root, 'pom.xml');
 
     if (fileExists(pomXmlPath)) {
       const pomXmlContent = readXml2(pomXmlPath);

--- a/packages/nx-boot-maven/src/utils/fileutils.ts
+++ b/packages/nx-boot-maven/src/utils/fileutils.ts
@@ -1,0 +1,9 @@
+import { statSync } from "fs";
+
+export function fileExists(filePath: string): boolean {
+  try {
+    return statSync(filePath).isFile();
+  } catch (err) {
+    return false;
+  }
+}


### PR DESCRIPTION
Make dep-graph plugin compatible with nx > 14.2.

Use a local `fileExists` util function instead of using nx
dev-kit's that has been removed.

Fixes #41