### PR TITLE
fix(nx-boot-maven): serve app with no args

### DIFF
--- a/packages/nx-boot-maven/src/executors/serve/executor.spec.ts
+++ b/packages/nx-boot-maven/src/executors/serve/executor.spec.ts
@@ -32,6 +32,17 @@ describe('Serve Executor', () => {
 
   it('can run', async () => {
     const output = await executor(options, context);
+
     expect(output.success).toBe(true);
+    expect(runCommand).toHaveBeenCalledWith(expect.stringMatching(/spring-boot:run -pl :my-app args$/));
+  });
+
+  describe('when args option is undefined', () => {
+    it('run without extra args', async () => {
+      const output = await executor({} as ServeExecutorSchema, context);
+
+      expect(output.success).toBe(true);
+      expect(runCommand).toHaveBeenCalledWith(expect.stringMatching(/spring-boot:run -pl :my-app$/));
+    });
   });
 });

--- a/packages/nx-boot-maven/src/executors/serve/executor.ts
+++ b/packages/nx-boot-maven/src/executors/serve/executor.ts
@@ -8,8 +8,8 @@ export default async function runExecutor(
 ) {
   logger.info(`Executor ran for serve: ${JSON.stringify(options)}`);
   const result = runCommand(
-    `${getExecutable()} spring-boot:run -pl :${context.projectName} ${
-      options.args
+    `${getExecutable()} spring-boot:run -pl :${context.projectName}${
+      options.args ? ' ' + options.args : ''
     }`
   );
 


### PR DESCRIPTION
Fix serve executor when serving applicatios that have no extra
`args` in its projects settings.

Fixes #46