### PR TITLE
also make (-am) dependencies when running mvn

### DIFF
--- a/packages/nx-boot-maven/src/executors/build-image/executor.ts
+++ b/packages/nx-boot-maven/src/executors/build-image/executor.ts
@@ -8,7 +8,7 @@ export default async function runExecutor(
 ) {
   logger.info(`Executor ran for Build Image: ${JSON.stringify(options)}`);
   return runCommand(
-    `${getExecutable()} spring-boot:build-image -DskipTests=true -pl :${
+    `${getExecutable()} spring-boot:build-image -DskipTests=true -am -pl :${
       context.projectName
     }`
   );

--- a/packages/nx-boot-maven/src/executors/build/executor.ts
+++ b/packages/nx-boot-maven/src/executors/build/executor.ts
@@ -17,7 +17,7 @@ export default async function runExecutor(
   }
 
   return runCommand(
-    `${getExecutable()} ${target} -DskipTests=true -pl :${context.projectName}`,
+    `${getExecutable()} ${target} -DskipTests=true -am -pl :${context.projectName}`,
     `${getExecutable()} clean install -N`
   );
 }

--- a/packages/nx-boot-maven/src/executors/serve/executor.ts
+++ b/packages/nx-boot-maven/src/executors/serve/executor.ts
@@ -8,7 +8,7 @@ export default async function runExecutor(
 ) {
   logger.info(`Executor ran for serve: ${JSON.stringify(options)}`);
 
-  let command = `${getExecutable()} spring-boot:run -pl :${
+  let command = `${getExecutable()} spring-boot:run -am -pl :${
     context.projectName
   }`;
 

--- a/packages/nx-boot-maven/src/executors/test/executor.ts
+++ b/packages/nx-boot-maven/src/executors/test/executor.ts
@@ -7,5 +7,5 @@ export default async function runExecutor(
   context: ExecutorContext
 ) {
   logger.info(`Executor ran for Test: ${JSON.stringify(options)}`);
-  return runCommand(`${getExecutable()} test -pl :${context.projectName}`);
+  return runCommand(`${getExecutable()} test -am -pl :${context.projectName}`);
 }


### PR DESCRIPTION
maven does not build dependencies (libraries) automatically for projects identified by the `-pl` switch. The option `-am` fixes that.