### PR TITLE
Name the exported generators to be able to import them individually

### DIFF
--- a/packages/nx-boot-maven/generators.ts
+++ b/packages/nx-boot-maven/generators.ts
@@ -1,4 +1,6 @@
-export * from './src/generators/application/generator';
-export * from './src/generators/init/generator';
-export * from './src/generators/library/generator';
-export * from './src/generators/migrate/generator';
+import initGenerator from './src/generators/init/generator';
+import libraryGenerator from './src/generators/library/generator';
+import applicationGenerator from './src/generators/application/generator';
+import migrateGenerator from './src/generators/migrate/generator';
+
+export {initGenerator, libraryGenerator, applicationGenerator, migrateGenerator};


### PR DESCRIPTION
Exporting the generators was not enough as the generator function don't have names.
I remodified the export file to name the functions so that we can import them in our projects.