### PR TITLE
build: name generators entry points

### DIFF
--- a/packages/nx-boot-maven/src/generators/application/generator.ts
+++ b/packages/nx-boot-maven/src/generators/application/generator.ts
@@ -104,7 +104,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
   );
 }
 
-export default async function (
+ async function applicationGenerator (
   tree: Tree,
   options: NxBootMavenAppGeneratorSchema
 ) {
@@ -207,3 +207,6 @@ function addProjectToParentPomXml(tree: Tree, options: NormalizedSchema) {
   xmldoc.childNamed('modules').children.push(fragment);
   tree.write(filePath, xmlToString(xmldoc));
 }
+
+export default applicationGenerator;
+

--- a/packages/nx-boot-maven/src/generators/init/generator.ts
+++ b/packages/nx-boot-maven/src/generators/init/generator.ts
@@ -56,7 +56,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
   );
 }
 
-export default async function (
+async function initGenerator(
   tree: Tree,
   options: NxBootMavenGeneratorSchema
 ) {
@@ -110,3 +110,6 @@ function updatePrettierIgnore(tree: Tree) {
   const newContents = contents.concat(prettierIgnore);
   tree.write(filePath, newContents);
 }
+
+export default initGenerator;
+

--- a/packages/nx-boot-maven/src/generators/library/generator.ts
+++ b/packages/nx-boot-maven/src/generators/library/generator.ts
@@ -107,7 +107,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
   );
 }
 
-export default async function (
+async function libraryGenerator(
   tree: Tree,
   options: NxBootMavenLibGeneratorSchema
 ) {
@@ -194,3 +194,6 @@ function addLibraryToProjects(tree: Tree, options: NormalizedSchema) {
     tree.write(filePath, xmlToString(xmldoc));
   }
 }
+
+export default libraryGenerator;
+

--- a/packages/nx-boot-maven/src/generators/migrate/generator.ts
+++ b/packages/nx-boot-maven/src/generators/migrate/generator.ts
@@ -40,7 +40,7 @@ function addFiles(tree: Tree, options: NormalizedSchema) {
   );
 }
 
-export default async function (
+async function migrateGenerator(
   tree: Tree,
   options: NxBootMavenGeneratorSchema
 ) {
@@ -50,3 +50,6 @@ export default async function (
   tree.changePermissions('mvnw.cmd', '755');
   await formatFiles(tree);
 }
+
+export default migrateGenerator;
+


### PR DESCRIPTION
Give generators entry point functions a name so they can be imported by other generators and plugins.

Relates to #118