### PR TITLE
Add mvnArgs to TestExecutor

### DIFF
--- a/packages/nx-boot-maven/src/executors/test/executor.ts
+++ b/packages/nx-boot-maven/src/executors/test/executor.ts
@@ -7,5 +7,11 @@ export default async function runExecutor(
   context: ExecutorContext
 ) {
   logger.info(`Executor ran for Test: ${JSON.stringify(options)}`);
-  return runCommand(`${getExecutable()} test -pl :${context.projectName}`);
+  let command = getExecutable();
+  command += ` test -pl :${context.projectName}`;
+
+  if (options.mvnArgs) {
+    command += ` ${options.mvnArgs}`;
+  }
+  return runCommand(command);
 }

--- a/packages/nx-boot-maven/src/executors/test/schema.d.ts
+++ b/packages/nx-boot-maven/src/executors/test/schema.d.ts
@@ -1,1 +1,3 @@
-export interface TestExecutorSchema {} // eslint-disable-line
+export interface TestExecutorSchema {
+  mvnArgs?: string;
+}

--- a/packages/nx-boot-maven/src/executors/test/schema.json
+++ b/packages/nx-boot-maven/src/executors/test/schema.json
@@ -6,6 +6,11 @@
   "title": "Test executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "mvnArgs": {
+      "type": "string",
+      "description": "Arguments to pass to the maven cli"
+    }
+  },
   "required": []
 }


### PR DESCRIPTION
Hi,

We came across needing to pass some arguments to maven for tests (in our case, to specify when to include codecov reports). Decided to contribute a PR for it :)