### PR TITLE
feat: Add dependsOn: ['build'] to test target for libs

### DIFF
--- a/packages/nx-maven/src/generators/library/generator.ts
+++ b/packages/nx-maven/src/generators/library/generator.ts
@@ -310,6 +310,7 @@ async function libraryGenerator(
         options: {
           task: 'test',
         },
+        dependsOn: ['build'],
       },
     },
     tags: normalizedOptions.parsedTags,


### PR DESCRIPTION
Consider the following scenario:

App:
example-app

Libs:
example-lib-core
example-lib-1
example-lib-2

example-app has a dependency to example-lib-1 .
example-lib-1 and example-lib-2 have a dependency to example-lib-core.

When I run `nx run-many -t test -p  example-lib-1 example-lib-2`, I will run into errors that example-lib-core cannot be found in the .m2 repository. Adding dependsOn: ['build'] seems to fix this issue, because it will trigger a build om example-lib-core.

Going for ^build instead of build will cause concurrency issues. This would be able to trigger both test and build at the same time, causing FileNotFoundExceptions.

Please let me know if my train of thought is wrong here, but this seems to be the solution for our project.