### PR TITLE
fix(common): allow multiple hyphen in target name

### DIFF
--- a/packages/common/src/lib/utils/index.ts
+++ b/packages/common/src/lib/utils/index.ts
@@ -51,7 +51,7 @@ export function getTargetName(context: ExecutorContext) {
   if (!context.targetName) {
     throw new Error('TargetName not found in context');
   }
-  return titleCase(context.targetName.replace(/-/g, ' '));
+  return titleCase(context.targetName.replace(/-+/g, ' '));
 }
 
 export function clearEmpties(o: TargetsType) {


### PR DESCRIPTION
Hey,

I’m currently working on integrating [[Atomizer](https://nx.dev/ci/features/split-e2e-tasks#automatically-split-e2e-tasks-by-file-atomizer)](https://nx.dev/ci/features/split-e2e-tasks#automatically-split-e2e-tasks-by-file-atomizer) for `surefire:test`, and I noticed a common convention is to name the target like this:

```
nx run my-project:maven-test-ci--MyTest.java
```

As you can see, we’re using a double `--` to separate parts of the target. However, your utility splits the name using a single `-`, which is causing an issue.

Specifically, it results in an empty string in the `titleCase` function, leading to an error at this line:
`word[0].toUpperCase()`
Because `word` is empty in that case.